### PR TITLE
fix: Simplify null checks for encryptionSalt and namespace, avoiding infinite loop

### DIFF
--- a/packages/simple_secure_storage_web/lib/src/initialization_options.dart
+++ b/packages/simple_secure_storage_web/lib/src/initialization_options.dart
@@ -44,8 +44,8 @@ class WebInitializationOptions extends InitializationOptions {
   }
 
   /// Returns the encryption salt, or a default value if not specified.
-  String get encryptionSalt => _encryptionSalt == null ? '_salt' : _encryptionSalt;
+  String get encryptionSalt => _encryptionSalt ?? '_salt';
 
   /// Returns the namespace, or a default value if not specified.
-  String get namespace => super.namespace == null ? 'fr.skyost.simple_secure_storage' : namespace;
+  String get namespace => super.namespace ?? 'fr.skyost.simple_secure_storage';
 }


### PR DESCRIPTION
This PR fixes an infinite loop that occurs when providing a namespace to `WebInitializationOptions`