### PR TITLE
fix: prevent ANR/freezes with Flutter Thread Merge (3.29+) [Android] [iOS]

### DIFF
--- a/packages/simple_secure_storage_darwin/darwin/Classes/SimpleSecureStoragePlugin.swift
+++ b/packages/simple_secure_storage_darwin/darwin/Classes/SimpleSecureStoragePlugin.swift
@@ -34,94 +34,94 @@ public class SimpleSecureStoragePlugin: NSObject, FlutterPlugin {
         let arguments: [String: Any?] = call.arguments == nil ? [:] : (call.arguments as! [String: Any?])
         switch call.method {
         case "initialize":
-            DispatchQueue.global(qos: .userInitiated).async {
+            executeInBackground(result: result) {
                 self.initialize(arguments["appName"] == nil ? "Flutter" : (arguments["appName"] as! String))
-                DispatchQueue.main.async {
-                    result(true)
-                }
+                return true
             }
         case "has":
             if !ensureInitialized(result) {
                 return
             }
-            DispatchQueue.global(qos: .userInitiated).async {
-                let hasResult = self.has(arguments["key"] as! String)
-                DispatchQueue.main.async {
-                    result(hasResult)
-                }
+            executeInBackground(result: result) {
+                self.has(arguments["key"] as! String)
             }
         case "read":
             if !ensureInitialized(result) {
                 return
             }
-            DispatchQueue.global(qos: .userInitiated).async {
+            executeInBackground(result: result) {
                 let readResult = self.read(arguments["key"] as! String)
-                DispatchQueue.main.async {
-                    if readResult.0 == noErr {
-                        result(readResult.1)
-                    } else {
-                        result(FlutterError(code: "read_error", message: "Error while reading.", details: readResult.0))
-                    }
+                if readResult.0 == noErr {
+                    return readResult.1
+                } else {
+                    return FlutterError(code: "read_error", message: "Error while reading.", details: readResult.0)
                 }
             }
         case "list":
             if !ensureInitialized(result) {
                 return
             }
-            DispatchQueue.global(qos: .userInitiated).async {
+            executeInBackground(result: result) {
                 let listResult = self.list()
-                DispatchQueue.main.async {
-                    if listResult.0 == noErr {
-                        result(listResult.1)
-                    } else {
-                        result(FlutterError(code: "list_error", message: "Error while listing.", details: listResult.0))
-                    }
+                if listResult.0 == noErr {
+                    return listResult.1
+                } else {
+                    return FlutterError(code: "list_error", message: "Error while listing.", details: listResult.0)
                 }
             }
         case "write":
             if !ensureInitialized(result) {
                 return
             }
-            DispatchQueue.global(qos: .userInitiated).async {
+            executeInBackground(result: result) {
                 let status = self.write(arguments["key"] as! String, arguments["value"] as! String)
-                DispatchQueue.main.async {
-                    if status == noErr {
-                        result(true)
-                    } else {
-                        result(FlutterError(code: "write_error", message: "Error while writing data.", details: status))
-                    }
+                if status == noErr {
+                    return true
+                } else {
+                    return FlutterError(code: "write_error", message: "Error while writing data.", details: status)
                 }
             }
         case "delete":
             if !ensureInitialized(result) {
                 return
             }
-            DispatchQueue.global(qos: .userInitiated).async {
+            executeInBackground(result: result) {
                 let status = self.delete(arguments["key"] as! String)
-                DispatchQueue.main.async {
-                    if status == noErr {
-                        result(true)
-                    } else {
-                        result(FlutterError(code: "delete_error", message: "Error while deleting data.", details: status))
-                    }
+                if status == noErr {
+                    return true
+                } else {
+                    return FlutterError(code: "delete_error", message: "Error while deleting data.", details: status)
                 }
             }
         case "clear":
             if !ensureInitialized(result) {
                 return
             }
-            DispatchQueue.global(qos: .userInitiated).async {
+            executeInBackground(result: result) {
                 let status = self.clear()
-                DispatchQueue.main.async {
-                    if status == noErr {
-                        result(true)
-                    } else {
-                        result(FlutterError(code: "clear_error", message: "Error while clearing data.", details: status))
-                    }
+                if status == noErr {
+                    return true
+                } else {
+                    return FlutterError(code: "clear_error", message: "Error while clearing data.", details: status)
                 }
             }
         default:
             result(FlutterMethodNotImplemented)
+        }
+    }
+
+    /// Executes an operation in a background thread to prevent UI freezes.
+    /// Results are posted back to the main thread.
+    ///
+    /// - Parameters:
+    ///   - result: The FlutterResult to send back to Flutter.
+    ///   - operation: The operation to execute in background.
+    private func executeInBackground(result: @escaping FlutterResult, operation: @escaping () -> Any?) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let operationResult = operation()
+            DispatchQueue.main.async {
+                result(operationResult)
+            }
         }
     }
 

--- a/packages/simple_secure_storage_darwin/darwin/Classes/SimpleSecureStoragePlugin.swift
+++ b/packages/simple_secure_storage_darwin/darwin/Classes/SimpleSecureStoragePlugin.swift
@@ -34,62 +34,91 @@ public class SimpleSecureStoragePlugin: NSObject, FlutterPlugin {
         let arguments: [String: Any?] = call.arguments == nil ? [:] : (call.arguments as! [String: Any?])
         switch call.method {
         case "initialize":
-            initialize(arguments["appName"] == nil ? "Flutter" : (arguments["appName"] as! String))
-            result(true)
+            DispatchQueue.global(qos: .userInitiated).async {
+                self.initialize(arguments["appName"] == nil ? "Flutter" : (arguments["appName"] as! String))
+                DispatchQueue.main.async {
+                    result(true)
+                }
+            }
         case "has":
             if !ensureInitialized(result) {
                 return
             }
-            result(has(arguments["key"] as! String))
+            DispatchQueue.global(qos: .userInitiated).async {
+                let hasResult = self.has(arguments["key"] as! String)
+                DispatchQueue.main.async {
+                    result(hasResult)
+                }
+            }
         case "read":
             if !ensureInitialized(result) {
                 return
             }
-            let readResult = read(arguments["key"] as! String)
-            if readResult.0 == noErr {
-                result(readResult.1)
-            } else {
-                result(FlutterError(code: "read_error", message: "Error while reading.", details: readResult.0))
+            DispatchQueue.global(qos: .userInitiated).async {
+                let readResult = self.read(arguments["key"] as! String)
+                DispatchQueue.main.async {
+                    if readResult.0 == noErr {
+                        result(readResult.1)
+                    } else {
+                        result(FlutterError(code: "read_error", message: "Error while reading.", details: readResult.0))
+                    }
+                }
             }
         case "list":
             if !ensureInitialized(result) {
                 return
             }
-            let listResult = list()
-            if listResult.0 == noErr {
-                result(listResult.1)
-            } else {
-                result(FlutterError(code: "list_error", message: "Error while listing.", details: listResult.0))
+            DispatchQueue.global(qos: .userInitiated).async {
+                let listResult = self.list()
+                DispatchQueue.main.async {
+                    if listResult.0 == noErr {
+                        result(listResult.1)
+                    } else {
+                        result(FlutterError(code: "list_error", message: "Error while listing.", details: listResult.0))
+                    }
+                }
             }
         case "write":
             if !ensureInitialized(result) {
                 return
             }
-            let status = write(arguments["key"] as! String, arguments["value"] as! String)
-            if status == noErr {
-                result(true)
-            } else {
-                result(FlutterError(code: "write_error", message: "Error while writing data.", details: status))
+            DispatchQueue.global(qos: .userInitiated).async {
+                let status = self.write(arguments["key"] as! String, arguments["value"] as! String)
+                DispatchQueue.main.async {
+                    if status == noErr {
+                        result(true)
+                    } else {
+                        result(FlutterError(code: "write_error", message: "Error while writing data.", details: status))
+                    }
+                }
             }
         case "delete":
             if !ensureInitialized(result) {
                 return
             }
-            let status = delete(arguments["key"] as! String)
-            if status == noErr {
-                result(true)
-            } else {
-                result(FlutterError(code: "delete_error", message: "Error while deleting data.", details: status))
+            DispatchQueue.global(qos: .userInitiated).async {
+                let status = self.delete(arguments["key"] as! String)
+                DispatchQueue.main.async {
+                    if status == noErr {
+                        result(true)
+                    } else {
+                        result(FlutterError(code: "delete_error", message: "Error while deleting data.", details: status))
+                    }
+                }
             }
         case "clear":
             if !ensureInitialized(result) {
                 return
             }
-            let status = clear()
-            if status == noErr {
-                result(true)
-            } else {
-                result(FlutterError(code: "clear_error", message: "Error while clearing data.", details: status))
+            DispatchQueue.global(qos: .userInitiated).async {
+                let status = self.clear()
+                DispatchQueue.main.async {
+                    if status == noErr {
+                        result(true)
+                    } else {
+                        result(FlutterError(code: "clear_error", message: "Error while clearing data.", details: status))
+                    }
+                }
             }
         default:
             result(FlutterMethodNotImplemented)


### PR DESCRIPTION
## Summary

Use ExecutorService in Android and DispatchQueue in iOS to fetch/write data in background thread.

With Flutter 3.29+, the UI Thread merged with Platform Thread. Blocking I/O operations now block the OS main thread, causing ANR on Android and freezes on iOS. This fix moves all storage operations to background threads.

 ## Changes

- Android: Added `ExecutorService` + `executeInBackground()` helper
- iOS: Added `DispatchQueue.global()` + `executeInBackground()` helper
- All operations (`initialize`, `read`, `write`, `delete`, `clear`, `list`) now run in background

## Refs

https://www.youtube.com/watch?v=miW7vCmQwnw

